### PR TITLE
fix creating url from route

### DIFF
--- a/GitHawkRoutes/Routable.swift
+++ b/GitHawkRoutes/Routable.swift
@@ -13,3 +13,13 @@ public protocol Routable {
     var encoded: [String: String] { get }
     static var path: String { get }
 }
+
+public extension URL {
+    public static func from<T: Routable>(githawk route: T) -> URL? {
+        var components = URLComponents()
+        components.host = "freetime"
+        components.queryItems = route.encoded.map(URLQueryItem.init)
+        components.path = T.path
+        return components.url
+    }
+}

--- a/GitHawkRoutes/Routable.swift
+++ b/GitHawkRoutes/Routable.swift
@@ -14,8 +14,8 @@ public protocol Routable {
     static var path: String { get }
 }
 
-public extension URL {
-    public static func from<T: Routable>(githawk route: T) -> URL? {
+internal extension URL {
+    internal static func from<T: Routable>(githawk route: T) -> URL? {
         var components = URLComponents()
         components.scheme = "freetime"
         components.host = T.path

--- a/GitHawkRoutes/Routable.swift
+++ b/GitHawkRoutes/Routable.swift
@@ -17,9 +17,9 @@ public protocol Routable {
 public extension URL {
     public static func from<T: Routable>(githawk route: T) -> URL? {
         var components = URLComponents()
-        components.host = "freetime"
+        components.scheme = "freetime"
+        components.host = T.path
         components.queryItems = route.encoded.map(URLQueryItem.init)
-        components.path = T.path
         return components.url
     }
 }

--- a/GitHawkRoutes/UIApplication+Routable.swift
+++ b/GitHawkRoutes/UIApplication+Routable.swift
@@ -14,11 +14,8 @@ public extension UIApplication {
         githawk route: T,
         completion: ((Bool) -> Void)? = nil
         ) {
-        var components = URLComponents()
-        components.host = "freetime"
-        components.queryItems = route.encoded.map(URLQueryItem.init)
-        components.path = T.path
-        guard let url = components.url,
+
+        guard let url = URL.from(githawk: route),
             canOpenURL(url)
             else {
                 completion?(false)

--- a/GitHawkRoutesTests/GitHawkRoutesTests.swift
+++ b/GitHawkRoutesTests/GitHawkRoutesTests.swift
@@ -17,9 +17,14 @@ class GitHawkRoutesTests: XCTestCase {
             repo: "GitHawk",
             branch: "master"
         )
-        let url = URL.from(githawk: repo)
+        let url = URL.from(githawk: repo)!
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         
-        XCTAssertNotNil(url)
+        XCTAssertEqual("freetime", components.scheme)
+        XCTAssertEqual("com.githawk.repo", components.host)
+        XCTAssertEqual("GitHawkApp", components.queryItems?.first(where: { $0.name == "owner"})!.value)
+        XCTAssertEqual("GitHawk", components.queryItems?.first(where: { $0.name == "repo"})!.value)
+        XCTAssertEqual("master", components.queryItems?.first(where: { $0.name == "branch"})!.value)
     }
 
 }

--- a/GitHawkRoutesTests/GitHawkRoutesTests.swift
+++ b/GitHawkRoutesTests/GitHawkRoutesTests.swift
@@ -11,6 +11,15 @@ import XCTest
 
 class GitHawkRoutesTests: XCTestCase {
 
-    
+    func testRepo() {
+        let repo = RepoRoute(
+            owner: "GitHawkApp",
+            repo: "GitHawk",
+            branch: "master"
+        )
+        let url = URL.from(githawk: repo)
+        
+        XCTAssertNotNil(url)
+    }
 
 }


### PR DESCRIPTION
It looks like there is some kind of mismatch when populating ``URLComponents`` such that ``scheme`` is never set and then you never get any url.

This PR makes it obvious by extracting the logic to create a url from a route and having a unit test with the example from the README.

Maybe it should be ``components.scheme = "freetime"`` but I'm not sure what needs to happen to the other components. I'm hoping this PR can help even though it only points out a problem.

